### PR TITLE
支持多页pdf识别、增加最小的演示用代码（不需要任何操作，直接python运行就能出结果）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ htmlcov/
 .mypy_cache/
 .dmypy.json
 dmypy.json
-
+*output.md
 # Environment variables
 .env
 .env.local

--- a/deepseek_ocr/client.py
+++ b/deepseek_ocr/client.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
 import aiohttp
-import fitz  # PyMuPDF
+import fitz  # PyMuPDF，fitz（在 Python 中来自包 PyMuPDF）是 MuPDF 的 Python 绑定，用于读取、渲染和操作 PDF/电子文档（也支持 EPUB、CBZ、XPS 等），常用于把 PDF 页面渲染成图片、提取文字/图片/注释、操作页面等。
 import requests
 
 from .config import OCRConfig
@@ -28,6 +28,8 @@ class DeepSeekOCR:
 
     This client provides both synchronous and asynchronous methods for
     document OCR processing using the DeepSeek OCR API.
+
+
 
     Example:
         >>> # Synchronous usage
@@ -56,6 +58,11 @@ class DeepSeekOCR:
         max_tokens: Optional[int] = None,
         dpi: Optional[int] = None,
         **kwargs: str,
+
+        # prompt 应该增加一个prompt参数，官方给出的几个promt确实不错，但应该给用户自定的选择
+        #    OCRMode.FREE_OCR: "Free OCR.",
+        #    OCRMode.GROUNDING: "<|grounding|>Convert the document to markdown.",
+        #    OCRMode.OCR_IMAGE: "<|grounding|>OCR this image.",
     ):
         """
         Initialize DeepSeekOCR client.
@@ -119,12 +126,15 @@ class DeepSeekOCR:
 
             # Process only first page
             page = doc[0]
+            """
+            为什么要默认只处理第一页？不应该处理所有页吗？
+            """
             # Render page to image
-            mat = fitz.Matrix(dpi / 72, dpi / 72)
-            pix = page.get_pixmap(matrix=mat)
+            matrix = fitz.Matrix(dpi / 72, dpi / 72)
+            pixel = page.get_pixmap(matrix=matrix)
 
             # Convert to bytes
-            img_bytes = pix.tobytes("png")
+            img_bytes = pixel.tobytes("png")
             doc.close()
 
             # Encode to base64
@@ -200,8 +210,8 @@ class DeepSeekOCR:
                     ],
                 }
             ],
-            "temperature": self.config.temperature,
-            "max_tokens": self.config.max_tokens,
+            "temperature": self.config.temperature,  #不知道有什么用，需要设置吗？
+            "max_tokens": self.config.max_tokens,  #不知道有什么用，需要设置吗？
         }
 
         timeout = aiohttp.ClientTimeout(total=self.config.timeout)

--- a/deepseek_ocr/client.py
+++ b/deepseek_ocr/client.py
@@ -9,7 +9,7 @@ import base64
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, List
 
 import aiohttp
 import fitz  # PyMuPDF，fitz（在 Python 中来自包 PyMuPDF）是 MuPDF 的 Python 绑定，用于读取、渲染和操作 PDF/电子文档（也支持 EPUB、CBZ、XPS 等），常用于把 PDF 页面渲染成图片、提取文字/图片/注释、操作页面等。
@@ -101,9 +101,23 @@ class DeepSeekOCR:
             f"Initialized DeepSeekOCR client with model: {self.config.model_name}"
         )
 
-    def _pdf_to_base64(self, file_path: Union[str, Path], dpi: int) -> str:
+    def _build_prompt(self, mode: OCRMode) -> str:
         """
-        Convert PDF first page to base64-encoded image.
+        Build the prompt for the API request.
+
+        Args:
+            mode: OCR mode to use.
+
+        Returns:
+            Prompt string.
+        """
+        return mode.get_prompt()
+
+
+    def _pdf_to_base64s(self, file_path: Union[str, Path], dpi: int) -> List[str]:
+        """
+        Convert all PDF pages to base64-encoded images.
+        Returns a list of base64 image strings (one per page) in page order.
 
         Args:
             file_path: Path to the PDF file.
@@ -124,40 +138,34 @@ class DeepSeekOCR:
             if len(doc) == 0:
                 raise FileProcessingError(f"PDF has no pages: {file_path}")
 
-            # Process only first page
-            page = doc[0]
-            """
-            为什么要默认只处理第一页？不应该处理所有页吗？
-            """
-            # Render page to image
-            matrix = fitz.Matrix(dpi / 72, dpi / 72)
-            pixel = page.get_pixmap(matrix=matrix)
+            b64_images: List[str] = []
+            # Render every page
+            for i in range(len(doc)):
+                page = doc[i]
+                matrix = fitz.Matrix(dpi / 72, dpi / 72)  #为什么是dpi/72？dpi不是设置150、200、300吗？是不是应该取公约数？
+                pixel = page.get_pixmap(matrix=matrix)
+                img_bytes = pixel.tobytes("png")
+                b64_images.append(base64.b64encode(img_bytes).decode("utf-8"))
 
-            # Convert to bytes
-            img_bytes = pixel.tobytes("png")
             doc.close()
-
-            # Encode to base64
-            b64_string = base64.b64encode(img_bytes).decode("utf-8")
             logger.debug(
-                f"Converted PDF to image: {len(b64_string)} bytes at {dpi} DPI"
+                f"Converted PDF to images: {len(b64_images)} pages at {dpi} DPI" #为什么是dpi/72？dpi不是设置150、200、300吗？是不是应该取公约数？
             )
-            return b64_string
+            return b64_images
 
         except Exception as e:
             raise FileProcessingError(f"Failed to process PDF: {e}") from e
 
-    def _build_prompt(self, mode: OCRMode) -> str:
+    def _parse_api_result(self, result: Dict[str, Any]) -> str:
         """
-        Build the prompt for the API request.
-
-        Args:
-            mode: OCR mode to use.
-
-        Returns:
-            Prompt string.
+        Parse the API result and return the cleaned text.
+        Raises APIError if the result is invalid.
         """
-        return mode.get_prompt()
+        if "choices" not in result or len(result["choices"]) == 0:
+            raise APIError("Invalid API response: no choices returned")
+
+        text = result["choices"][0]["message"]["content"]
+        return self._clean_output(text)
 
     def _clean_output(self, text: str) -> str:
         """
@@ -340,30 +348,65 @@ class DeepSeekOCR:
 
         # Convert PDF to base64
         logger.info(f"Processing {file_path} with mode={mode} and dpi={dpi}")
-        image_b64 = self._pdf_to_base64(file_path, dpi)
+        multi_page_pdf_image_b64 = self._pdf_to_base64s(file_path, dpi)
 
         # Build prompt
         prompt = self._build_prompt(mode)
 
-        # Make API request
-        result = await self._make_api_request_async(image_b64, prompt)
+        # If single page
+        if len(multi_page_pdf_image_b64) == 1:
+            result = await self._make_api_request_async(multi_page_pdf_image_b64[0], prompt)
+            text = self._parse_api_result(result)
+            # Log token usage
+            usage = result.get("usage", {})
+            logger.debug(
+                f"API usage: prompt_tokens={usage.get('prompt_tokens')}, "
+                f"completion_tokens={usage.get('completion_tokens')}, "
+                f"total_tokens={usage.get('total_tokens')}"
+            )
+        else:
+            # if Multiple pages: make concurrent requests and combine outputs
+            tasks = [self._make_api_request_async(img, prompt) for img in multi_page_pdf_image_b64]
+            results = await asyncio.gather(*tasks)
+            texts: List[str] = []
+            total_prompt_tokens = 0
+            total_completion_tokens = 0
+            total_tokens = 0
+            for idx, res in enumerate(results):
+                page_text = self._parse_api_result(res)
+                # Per-page fallback
+                if (
+                    self.config.fallback_enabled
+                    and mode == OCRMode.FREE_OCR
+                    and len(page_text) < self.config.min_output_threshold
+                ):
+                    logger.warning(
+                        f"Page {idx+1} output too short ({len(page_text)} chars), falling back to {self.config.fallback_mode}"
+                    )
+                    fallback_prompt = self._build_prompt(
+                        OCRMode(self.config.fallback_mode)
+                    )
+                    fallback_res = await self._make_api_request_async(multi_page_pdf_image_b64[idx], fallback_prompt)
+                    page_text = self._parse_api_result(fallback_res)
+                    # fallback usage
+                    usage = fallback_res.get("usage", {})
+                else:
+                    usage = res.get("usage", {})
 
-        # Extract text from response
-        if "choices" not in result or len(result["choices"]) == 0:
-            raise APIError("Invalid API response: no choices returned")
+                total_prompt_tokens += int(usage.get("prompt_tokens", 0))
+                total_completion_tokens += int(usage.get("completion_tokens", 0))
+                total_tokens += int(usage.get("total_tokens", 0))
+                texts.append(page_text)
 
-        text = result["choices"][0]["message"]["content"]
-        text = self._clean_output(text)
+            text = "\n\n".join(texts)
+            logger.debug(
+                f"API usage (aggregated): prompt_tokens={total_prompt_tokens}, "
+                f"completion_tokens={total_completion_tokens}, total_tokens={total_tokens}"
+            )
 
-        # Log token usage
-        usage = result.get("usage", {})
-        logger.debug(
-            f"API usage: prompt_tokens={usage.get('prompt_tokens')}, "
-            f"completion_tokens={usage.get('completion_tokens')}, "
-            f"total_tokens={usage.get('total_tokens')}"
-        )
+        # Note: single-page usage already logged; aggregated usage logged above for multi-page
 
-        # Intelligent fallback
+        # Intelligent fallback (for single-page results handled here)
         if (
             self.config.fallback_enabled
             and mode == OCRMode.FREE_OCR
@@ -424,20 +467,55 @@ class DeepSeekOCR:
 
         # Convert PDF to base64
         logger.info(f"Processing {file_path} with mode={mode} and dpi={dpi}")
-        image_b64 = self._pdf_to_base64(file_path, dpi)
+        images_b64 = self._pdf_to_base64s(file_path, dpi)
 
         # Build prompt
         prompt = self._build_prompt(mode)
 
-        # Make API request
-        result = self._make_api_request_sync(image_b64, prompt)
+        # If single page, keep old behavior
+        if len(images_b64) == 1:
+            result = self._make_api_request_sync(images_b64[0], prompt)
+            text = self._parse_api_result(result)
+            usage = result.get("usage", {})
+            logger.debug(
+                f"API usage: prompt_tokens={usage.get('prompt_tokens')}, "
+                f"completion_tokens={usage.get('completion_tokens')}, "
+                f"total_tokens={usage.get('total_tokens')}"
+            )
+        else:
+            texts: List[str] = []
+            total_prompt_tokens = 0
+            total_completion_tokens = 0
+            total_tokens = 0
+            for idx, img in enumerate(images_b64):
+                result = self._make_api_request_sync(img, prompt)
+                page_text = self._parse_api_result(result)
+                # Per-page fallback for sync
+                if (
+                    self.config.fallback_enabled
+                    and mode == OCRMode.FREE_OCR
+                    and len(page_text) < self.config.min_output_threshold
+                ):
+                    logger.warning(
+                        f"Page {idx+1} output too short ({len(page_text)} chars), falling back to {self.config.fallback_mode}"
+                    )
+                    fallback_prompt = self._build_prompt(OCRMode(self.config.fallback_mode))
+                    fallback_result = self._make_api_request_sync(img, fallback_prompt)
+                    page_text = self._parse_api_result(fallback_result)
+                    usage = fallback_result.get("usage", {})
+                else:
+                    usage = result.get("usage", {})
 
-        # Extract text from response
-        if "choices" not in result or len(result["choices"]) == 0:
-            raise APIError("Invalid API response: no choices returned")
+                total_prompt_tokens += int(usage.get("prompt_tokens", 0))
+                total_completion_tokens += int(usage.get("completion_tokens", 0))
+                total_tokens += int(usage.get("total_tokens", 0))
+                texts.append(page_text)
 
-        text = result["choices"][0]["message"]["content"]
-        text = self._clean_output(text)
+            text = "\n\n".join(texts)
+            logger.debug(
+                f"API usage (aggregated): prompt_tokens={total_prompt_tokens}, "
+                f"completion_tokens={total_completion_tokens}, total_tokens={total_tokens}"
+            )
 
         # Log token usage
         usage = result.get("usage", {})

--- a/deepseek_ocr/config.py
+++ b/deepseek_ocr/config.py
@@ -51,11 +51,11 @@ class OCRConfig:
     base_url: str
     model_name: str = "deepseek-ai/DeepSeek-OCR"
     timeout: int = 60
-    max_tokens: int = 4000
+    max_tokens: int = 4000 #为什么是4000？如果图片内容很多，4000会不会不够？
     temperature: float = 0.0
     dpi: int = 200
     fallback_enabled: bool = True
-    fallback_mode: str = "grounding"
+    fallback_mode: str = "free_ocr" #应该默认使用free_ocr模式（更通用更快），而不是grounding模式（用于识别复杂表格）
     min_output_threshold: int = 500
 
     def __post_init__(self) -> None:

--- a/examples/mini_example.py
+++ b/examples/mini_example.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import os
+from deepseek_ocr import DeepSeekOCR
+
+API_KEY = os.getenv("DS_OCR_API_KEY", "your_api_key_here")
+
+def main():
+    client = DeepSeekOCR(api_key=API_KEY)
+
+    # Robust, cross-platform path resolved relative to this example file
+    sample_pdf = Path(__file__).resolve().parent / "sample_docs" / "DeepSeek_OCR_paper.pdf"
+
+    if not sample_pdf.exists():
+        print(f"Error: expected sample file at {sample_pdf} not found.")
+        return
+
+    print("Example 1: Processing simple document with FREE_OCR...")
+    try:
+        text = client.parse(str(sample_pdf), mode="free_ocr")
+        print(f"Extracted text ({len(text)} chars):")
+        print(text)
+        print("\n" + "=" * 60 + "\n")
+        # Save result to a markdown file next to this example
+        out_path = Path(__file__).resolve().parent / "mini_usage_output.md"
+        try:
+            out_path.write_text(text, encoding="utf-8")
+            print(f"Saved OCR output to: {out_path}")
+        except Exception as w:
+            print(f"Failed to write output file: {w}")
+    except Exception as e:
+        print(f"Error: {e}\n")
+
+if __name__ == "__main__":
+    main()

--- a/examples/sample_docs/README.md
+++ b/examples/sample_docs/README.md
@@ -9,6 +9,11 @@ Place your sample PDF documents in this directory to test the examples.
 3. **chinese_document.pdf** - A document with Chinese text
 4. **doc1.pdf, doc2.pdf, doc3.pdf** - Additional documents for batch processing
 
+## mini_usage
+make a try just run
+```
+python examples/mini_usage.py
+```
 ## Notes
 
 - Sample documents are excluded from git (see .gitignore)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepseek-ocr"
-version = "0.1.1"
+version = "0.1.2"
 description = "A simple and efficient Python SDK for DeepSeek-OCR API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -542,7 +542,7 @@ wheels = [
 
 [[package]]
 name = "deepseek-ocr"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
# pr说明
## 主要更新
- 支持识别多页的pdf（实在不是很理解为什么之前的代码限制到只能识别第一页pdf） https://github.com/BukeLy/DeepSeek-OCR-SDK/pull/2/commits/a7226b7952899f21f0dc6ae5ca71539988da25fe
## 小更新
- 增加最小的演示用代码`examples/mini_example.py`，之前的example还需要手动上传文件，不够简单，这个mini_example不需要任何操作，直接python运行就能出结果，快速感受到deepseek-ocr的能力 https://github.com/BukeLy/DeepSeek-OCR-SDK/pull/2/commits/a7226b7952899f21f0dc6ae5ca71539988da25fe

# 其他
- @BukeLy 请增加一个dev分支，方便开发，最后通过main分支发布更新
- 备注一些源码的相关问题 https://github.com/BukeLy/DeepSeek-OCR-SDK/pull/2/commits/97561a4688256f870fef17c669fa7a16c102687d